### PR TITLE
Add edit_canvas, export_canvas, and search_canvases tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,22 @@ receiving the canvas as text/structured output.
     fallback is the canvas JSON).
 - **list_canvases** — List the `.canvas` files available in `OUTPUT_PATH`.
   - Returns: array of filenames.
+- **edit_canvas** — Add, update, and/or remove nodes and edges on a stored canvas in one
+  atomic write (a failed operation leaves the file unchanged).
+  - Input: `filename`, plus optional `add_nodes`, `update_nodes` (partial, must include `id`),
+    `remove_node_ids` (cascades connected edges), `add_edges`, `update_edges`, `remove_edge_ids`.
+  - Returns (structured): `{ path, node_count, edge_count, canvas }` — the updated canvas, so
+    UI-capable hosts re-render it inline.
+- **export_canvas** — Export a stored canvas to another format.
+  - Input: `filename`, `format` (`markdown` | `svg`).
+  - Returns (structured): `{ format, mime_type, content }`. Markdown is an edge-ordered outline;
+    SVG is a standalone vector image (node title lines only — plain SVG can't render Markdown).
+- **search_canvases** — Case-insensitive substring search across stored canvases.
+  - Input: `query`, optional `filename` to scope to one canvas.
+  - Returns (structured): `{ matches: [{ filename, kind, id, field, snippet }] }`.
 
-`create_canvas` and `read_canvas` are linked to the canvas viewer via `_meta.ui.resourceUri`,
-so UI-capable hosts render the result inline.
+`create_canvas`, `read_canvas`, and `edit_canvas` are linked to the canvas viewer via
+`_meta.ui.resourceUri`, so UI-capable hosts render the result inline.
 
 Node objects use the JSON Canvas shape: `id`, `type` (`text` | `file` | `link` | `group`),
 `x`, `y`, `width`, `height`, optional `color`, plus type-specific fields (`text`, `file`/`subpath`,

--- a/jsoncanvas/canvas.py
+++ b/jsoncanvas/canvas.py
@@ -179,6 +179,55 @@ class Canvas:
 
         return self.edges.pop(edge_index)
 
+    def update_node(self, node: Node) -> Node:
+        """Replace an existing node with a node sharing the same ID.
+
+        Connected edges are left intact (unlike :meth:`remove_node`). The
+        replacement node is already validated by its constructor.
+
+        Args:
+            node: The replacement node (must match an existing node ID)
+
+        Returns:
+            The previous node that was replaced
+
+        Raises:
+            ReferenceError: If no node with the given ID exists
+        """
+        for i, existing in enumerate(self.nodes):
+            if existing.id == node.id:
+                self.nodes[i] = node
+                return existing
+        raise ReferenceError(f"No node with ID {node.id} to update")
+
+    def update_edge(self, edge: Edge) -> Edge:
+        """Replace an existing edge with an edge sharing the same ID.
+
+        Args:
+            edge: The replacement edge (must match an existing edge ID)
+
+        Returns:
+            The previous edge that was replaced
+
+        Raises:
+            ReferenceError: If no edge with the given ID exists, or the edge
+                references a non-existent node
+        """
+        node_ids = {n.id for n in self.nodes}
+        if edge.from_node not in node_ids:
+            raise ReferenceError(
+                f"Edge references non-existent from_node: {edge.from_node}"
+            )
+        if edge.to_node not in node_ids:
+            raise ReferenceError(
+                f"Edge references non-existent to_node: {edge.to_node}"
+            )
+        for i, existing in enumerate(self.edges):
+            if existing.id == edge.id:
+                self.edges[i] = edge
+                return existing
+        raise ReferenceError(f"No edge with ID {edge.id} to update")
+
     def to_dict(self) -> Dict:
         """Convert the canvas to a dictionary.
 

--- a/jsoncanvas/export.py
+++ b/jsoncanvas/export.py
@@ -1,0 +1,325 @@
+"""Export a :class:`~jsoncanvas.canvas.Canvas` to other formats.
+
+``to_markdown`` produces an edge-ordered outline; ``to_svg`` produces a
+standalone vector image. Both are dependency-free and operate on the typed
+``Canvas`` model. SVG renders each node's title line only (plain SVG cannot
+render Markdown).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .canvas import Canvas
+    from .nodes import Node
+
+# JSON Canvas preset colours 1-6 (Obsidian palette); hex colours pass through.
+_PRESET = {
+    "1": "#fb464c",
+    "2": "#e9973f",
+    "3": "#e0de71",
+    "4": "#44cf6e",
+    "5": "#53dfdd",
+    "6": "#a882ff",
+}
+_DEFAULT_STROKE = "#8a8f98"
+
+
+def _color(value: str | None, fallback: str = _DEFAULT_STROKE) -> str:
+    if not value:
+        return fallback
+    return _PRESET.get(value, value)
+
+
+# --------------------------------------------------------------------------- #
+# Markdown
+# --------------------------------------------------------------------------- #
+def _node_title(node: Node) -> str:
+    """A one-line label for a node: first text line, else label/file/url/id."""
+    text = getattr(node, "text", None)
+    if text:
+        for line in text.splitlines():
+            stripped = line.strip().lstrip("#").strip()
+            if stripped:
+                return stripped
+    return (
+        getattr(node, "label", None)
+        or getattr(node, "file", None)
+        or getattr(node, "url", None)
+        or node.id
+    )
+
+
+def _node_body(node: Node) -> str:
+    """The detail block for a node beneath its heading (may be empty)."""
+    text = getattr(node, "text", None)
+    if text:
+        # Everything after the first non-empty (title) line.
+        lines = text.splitlines()
+        for i, line in enumerate(lines):
+            if line.strip():
+                return "\n".join(lines[i + 1 :]).strip()
+        return ""
+    file = getattr(node, "file", None)
+    if file:
+        subpath = getattr(node, "subpath", None) or ""
+        return f"File: `{file}{subpath}`"
+    url = getattr(node, "url", None)
+    if url:
+        return f"<{url}>"
+    return ""
+
+
+def to_markdown(canvas: Canvas, title: str = "Canvas") -> str:
+    """Render a canvas as a Markdown document.
+
+    Nodes are ordered by a depth-first walk of the edges starting from roots
+    (nodes with no incoming edge), so connected flows read top to bottom; any
+    remaining nodes (cycles/disconnected) follow. Edges are listed at the end.
+    """
+    nodes_by_id = {n.id: n for n in canvas.nodes}
+    children: dict[str, list[str]] = {}
+    indegree = {n.id: 0 for n in canvas.nodes}
+    for edge in canvas.edges:
+        children.setdefault(edge.from_node, []).append(edge.to_node)
+        if edge.to_node in indegree:
+            indegree[edge.to_node] += 1
+
+    roots = [n.id for n in canvas.nodes if indegree.get(n.id, 0) == 0]
+    if not roots:  # fully cyclic — fall back to document order
+        roots = [n.id for n in canvas.nodes]
+
+    order: list[str] = []
+    seen: set[str] = set()
+
+    def visit(node_id: str) -> None:
+        if node_id in seen or node_id not in nodes_by_id:
+            return
+        seen.add(node_id)
+        order.append(node_id)
+        for target in children.get(node_id, []):
+            visit(target)
+
+    for root in roots:
+        visit(root)
+    for node in canvas.nodes:  # leftovers
+        visit(node.id)
+
+    lines = [f"# {title}", ""]
+    for node_id in order:
+        node = nodes_by_id[node_id]
+        lines.append(f"## {_node_title(node)}")
+        body = _node_body(node)
+        if body:
+            lines.append("")
+            lines.append(body)
+        lines.append("")
+
+    if canvas.edges:
+        lines.append("## Connections")
+        for edge in canvas.edges:
+            frm = (
+                _node_title(nodes_by_id[edge.from_node])
+                if edge.from_node in nodes_by_id
+                else edge.from_node
+            )
+            to = (
+                _node_title(nodes_by_id[edge.to_node])
+                if edge.to_node in nodes_by_id
+                else edge.to_node
+            )
+            label = f" — {edge.label}" if edge.label else ""
+            lines.append(f"- {frm} → {to}{label}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip("\n") + "\n"
+
+
+# --------------------------------------------------------------------------- #
+# SVG
+# --------------------------------------------------------------------------- #
+_SIDES = ("top", "right", "bottom", "left")
+
+
+def _esc(text: str) -> str:
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+def _auto_side(a: Node, b: Node) -> str:
+    """Side of ``a`` facing ``b`` (used when an edge omits a side)."""
+    dx = (b.x + b.width / 2) - (a.x + a.width / 2)
+    dy = (b.y + b.height / 2) - (a.y + a.height / 2)
+    if abs(dx) > abs(dy):
+        return "right" if dx > 0 else "left"
+    return "bottom" if dy > 0 else "top"
+
+
+def _normal(side: str) -> tuple[float, float]:
+    return {
+        "top": (0.0, -1.0),
+        "bottom": (0.0, 1.0),
+        "left": (-1.0, 0.0),
+        "right": (1.0, 0.0),
+    }[side]
+
+
+def _anchor(node: Node, side: str, min_x: int, min_y: int) -> tuple[float, float]:
+    x = node.x - min_x
+    y = node.y - min_y
+    cx = x + node.width / 2
+    cy = y + node.height / 2
+    if side == "top":
+        return cx, y
+    if side == "bottom":
+        return cx, y + node.height
+    if side == "left":
+        return x, cy
+    return x + node.width, cy
+
+
+def _wrap(title: str, width: int, height: int) -> list[str]:
+    """Greedy word-wrap of a title to fit a node box (rough px estimate)."""
+    char_w = 7.5  # ~13px sans-serif
+    max_chars = max(4, int((width - 16) / char_w))
+    max_lines = max(1, int((height - 12) / 18))
+    words = title.split()
+    lines: list[str] = []
+    current = ""
+    for word in words:
+        candidate = f"{current} {word}".strip()
+        if len(candidate) <= max_chars:
+            current = candidate
+        else:
+            if current:
+                lines.append(current)
+            current = word
+        if len(lines) >= max_lines:
+            break
+    if current and len(lines) < max_lines:
+        lines.append(current)
+    if not lines:
+        lines = [title[:max_chars]]
+    # Truncate the last line if the title overflowed the available lines.
+    consumed = sum(len(line.split()) for line in lines)
+    if consumed < len(words) and lines:
+        last = lines[-1]
+        if len(last) >= max_chars - 1:
+            lines[-1] = last[: max_chars - 1] + "…"
+        else:
+            lines[-1] = last + " …"
+    return lines
+
+
+def to_svg(canvas: Canvas) -> str:
+    """Render a canvas as a standalone SVG string (light theme, titles only)."""
+    if not canvas.nodes:
+        return (
+            '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="120">'
+            '<text x="20" y="60" font-family="sans-serif" font-size="14" '
+            'fill="#666">Empty canvas</text></svg>'
+        )
+
+    pad = 40
+    min_x = min(n.x for n in canvas.nodes) - pad
+    min_y = min(n.y for n in canvas.nodes) - pad
+    max_x = max(n.x + n.width for n in canvas.nodes) + pad
+    max_y = max(n.y + n.height for n in canvas.nodes) + pad
+    w = max(1, max_x - min_x)
+    h = max(1, max_y - min_y)
+    nodes_by_id = {n.id: n for n in canvas.nodes}
+
+    parts: list[str] = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{w}" height="{h}" '
+        f'viewBox="0 0 {w} {h}" font-family="-apple-system, system-ui, sans-serif">'
+    ]
+    parts.append(f'<rect width="{w}" height="{h}" fill="#ffffff"/>')
+
+    # Arrow markers, one per distinct edge colour.
+    marker_ids: dict[str, str] = {}
+    marker_defs: list[str] = []
+    for edge in canvas.edges:
+        col = _color(getattr(edge, "color", None))
+        if col not in marker_ids:
+            mid = f"arrow{len(marker_ids)}"
+            marker_ids[col] = mid
+            marker_defs.append(
+                f'<marker id="{mid}" viewBox="0 0 10 10" refX="8" refY="5" '
+                f'markerWidth="7" markerHeight="7" orient="auto-start-reverse">'
+                f'<path d="M0,0 L10,5 L0,10 z" fill="{col}"/></marker>'
+            )
+    if marker_defs:
+        parts.append("<defs>" + "".join(marker_defs) + "</defs>")
+
+    # Edges (drawn under nodes).
+    for edge in canvas.edges:
+        a = nodes_by_id.get(edge.from_node)
+        b = nodes_by_id.get(edge.to_node)
+        if a is None or b is None:
+            continue
+        from_side = getattr(edge, "from_side", None) or _auto_side(a, b)
+        to_side = getattr(edge, "to_side", None) or _auto_side(b, a)
+        ax, ay = _anchor(a, from_side, min_x, min_y)
+        bx, by = _anchor(b, to_side, min_x, min_y)
+        k = max(40.0, ((bx - ax) ** 2 + (by - ay) ** 2) ** 0.5 * 0.4)
+        nax, nay = _normal(from_side)
+        nbx, nby = _normal(to_side)
+        c1x, c1y = ax + nax * k, ay + nay * k
+        c2x, c2y = bx + nbx * k, by + nby * k
+        col = _color(getattr(edge, "color", None))
+        marker = ""
+        if (getattr(edge, "to_end", None) or "arrow") == "arrow":
+            marker = f' marker-end="url(#{marker_ids[col]})"'
+        start_marker = ""
+        if (getattr(edge, "from_end", None) or "none") == "arrow":
+            start_marker = f' marker-start="url(#{marker_ids[col]})"'
+        parts.append(
+            f'<path d="M{ax:.1f},{ay:.1f} C{c1x:.1f},{c1y:.1f} {c2x:.1f},{c2y:.1f} '
+            f'{bx:.1f},{by:.1f}" fill="none" stroke="{col}" stroke-width="2"'
+            f"{marker}{start_marker}/>"
+        )
+        if getattr(edge, "label", None):
+            lx, ly = (ax + bx) / 2, (ay + by) / 2
+            parts.append(
+                f'<text x="{lx:.1f}" y="{ly:.1f}" font-size="12" fill="#333" '
+                f'text-anchor="middle" paint-order="stroke" stroke="#ffffff" '
+                f'stroke-width="3">{_esc(edge.label)}</text>'
+            )
+
+    # Nodes (groups first so they sit behind).
+    ordered = sorted(canvas.nodes, key=lambda n: 0 if n.type == "group" else 1)
+    for node in ordered:
+        x = node.x - min_x
+        y = node.y - min_y
+        stroke = _color(getattr(node, "color", None), "#c8ccd2")
+        if node.type == "group":
+            parts.append(
+                f'<rect x="{x}" y="{y}" width="{node.width}" height="{node.height}" '
+                f'rx="10" fill="{stroke}" fill-opacity="0.06" stroke="{stroke}" '
+                f'stroke-width="2" stroke-dasharray="6 4"/>'
+            )
+            label = getattr(node, "label", None)
+            if label:
+                parts.append(
+                    f'<text x="{x + 10}" y="{y + 20}" font-size="13" '
+                    f'font-weight="600" fill="#333">{_esc(label)}</text>'
+                )
+            continue
+        parts.append(
+            f'<rect x="{x}" y="{y}" width="{node.width}" height="{node.height}" '
+            f'rx="8" fill="#ffffff" stroke="{stroke}" stroke-width="2"/>'
+        )
+        title_lines = _wrap(_node_title(node), node.width, node.height)
+        for i, line in enumerate(title_lines):
+            parts.append(
+                f'<text x="{x + 10}" y="{y + 24 + i * 18}" font-size="13" '
+                f'fill="#1a1a1a">{_esc(line)}</text>'
+            )
+
+    parts.append("</svg>")
+    return "".join(parts)

--- a/jsoncanvas/server.py
+++ b/jsoncanvas/server.py
@@ -2,9 +2,9 @@
 """MCP server for JSON Canvas files.
 
 Built on the FastMCP API of the official ``mcp`` SDK, which negotiates the
-2025-11-25 Model Context Protocol revision. Exposes four tools (create, validate,
-read, list) and two resources (schema, example) over either stdio (default) or
-the Streamable HTTP transport.
+2025-11-25 Model Context Protocol revision. Exposes seven tools (create, validate,
+read, list, edit, export, search) plus a canvas-viewer UI resource over either
+stdio (default) or the Streamable HTTP transport.
 """
 
 from __future__ import annotations
@@ -15,7 +15,7 @@ import os
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from mcp.server.fastmcp import FastMCP
 from pydantic import BaseModel, Field
@@ -29,6 +29,7 @@ from jsoncanvas import (
     TextNode,
     __version__,
 )
+from jsoncanvas.export import to_markdown, to_svg
 
 
 # --------------------------------------------------------------------------- #
@@ -62,6 +63,32 @@ class ValidateCanvasResult(BaseModel):
     valid: bool = Field(description="True when the canvas conforms to the spec")
     error: str | None = Field(
         default=None, description="Validation error message when invalid"
+    )
+
+
+class ExportResult(BaseModel):
+    """Result of exporting a canvas to another format."""
+
+    format: str = Field(description="The export format (markdown or svg)")
+    mime_type: str = Field(description="MIME type of the exported content")
+    content: str = Field(description="The exported document text")
+
+
+class SearchMatch(BaseModel):
+    """A single search hit within a stored canvas."""
+
+    filename: str = Field(description="Canvas file the match was found in")
+    kind: str = Field(description="What matched: 'node' or 'edge'")
+    id: str = Field(description="ID of the matching node or edge")
+    field: str = Field(description="Field the query matched (e.g. text, label, url)")
+    snippet: str = Field(description="The matching value")
+
+
+class SearchResult(BaseModel):
+    """Result of searching across stored canvases."""
+
+    matches: list[SearchMatch] = Field(
+        default_factory=list, description="Matching nodes and edges"
     )
 
 
@@ -152,24 +179,37 @@ def _load_ui_html() -> str:
         ) from exc
 
 
+def _node_from_dict(node_data: dict[str, Any]):
+    """Build a single node from a JSON Canvas node dict (validates fields)."""
+    data = dict(node_data)  # copy so caller input is not mutated
+    node_type = data.pop("type", None)
+    node_cls = _NODE_TYPES.get(node_type)
+    if node_cls is None:
+        raise ValueError(f"Unknown node type: {node_type!r}")
+    # JSON Canvas uses camelCase "backgroundStyle"; the model expects snake_case.
+    if node_type == "group" and "backgroundStyle" in data:
+        data["background_style"] = data.pop("backgroundStyle")
+    return node_cls(**data)
+
+
 def _build_canvas(
     nodes: list[dict[str, Any]], edges: list[dict[str, Any]] | None
 ) -> Canvas:
     """Build and validate a :class:`Canvas` from JSON Canvas node/edge dicts."""
     canvas = Canvas()
     for node_data in nodes:
-        data = dict(node_data)  # copy so caller input is not mutated
-        node_type = data.pop("type", None)
-        node_cls = _NODE_TYPES.get(node_type)
-        if node_cls is None:
-            raise ValueError(f"Unknown node type: {node_type!r}")
-        # JSON Canvas uses camelCase "backgroundStyle"; the model expects snake_case.
-        if node_type == "group" and "backgroundStyle" in data:
-            data["background_style"] = data.pop("backgroundStyle")
-        canvas.add_node(node_cls(**data))
+        canvas.add_node(_node_from_dict(node_data))
     for edge_data in edges or []:
         canvas.add_edge(Edge.from_dict(edge_data))
     return canvas
+
+
+def _load_canvas(filename: str) -> tuple[Path, Canvas]:
+    """Load a stored canvas as a validated :class:`Canvas`, with its file path."""
+    target = _safe_target(filename)
+    if not target.is_file():
+        raise ValueError(f"Canvas not found: {target.name}")
+    return target, Canvas.from_dict(json.loads(target.read_text()))
 
 
 # --------------------------------------------------------------------------- #
@@ -265,6 +305,173 @@ def read_canvas(filename: str) -> CanvasDocument:
 def list_canvases() -> list[str]:
     """Return the names of ``.canvas`` files in the output directory."""
     return sorted(p.name for p in _output_dir().glob("*.canvas"))
+
+
+@mcp.tool(
+    title="Edit Canvas",
+    description=(
+        "Edit a stored .canvas file: add, update, and/or remove nodes and edges in "
+        "one atomic write. Operations apply in order — add_nodes, update_nodes, "
+        "add_edges, update_edges, remove_edge_ids, remove_node_ids — and removing a "
+        "node also removes its connected edges. If any operation fails the file is "
+        "left unchanged. Returns the updated canvas."
+    ),
+    meta=UI_TOOL_META,
+)
+def edit_canvas(
+    filename: str,
+    add_nodes: list[dict[str, Any]] | None = None,
+    update_nodes: list[dict[str, Any]] | None = None,
+    remove_node_ids: list[str] | None = None,
+    add_edges: list[dict[str, Any]] | None = None,
+    update_edges: list[dict[str, Any]] | None = None,
+    remove_edge_ids: list[str] | None = None,
+) -> CreateCanvasResult:
+    """Apply a batch of edits to a stored canvas and persist the result.
+
+    Changes are applied to an in-memory canvas and only written if every
+    operation succeeds, so a failed edit leaves the stored file untouched.
+
+    Args:
+        filename: Name of the canvas file under OUTPUT_PATH.
+        add_nodes: Full JSON Canvas node objects to add (``id``, ``type``, ``x``,
+            ``y``, ``width``, ``height`` plus type-specific fields).
+        update_nodes: Partial node objects to patch; each must include ``id``.
+            Fields are merged onto the existing node (its ``type`` is preserved
+            unless overridden — changing type requires the new type's fields).
+        remove_node_ids: Node IDs to remove (their connected edges are removed too).
+        add_edges: JSON Canvas edge objects to add (``id``, ``fromNode``, ``toNode``,
+            plus optional ``fromSide``/``toSide``/``color``/``label``).
+        update_edges: Partial edge objects to patch; each must include ``id``.
+        remove_edge_ids: Edge IDs to remove.
+    """
+    target, canvas = _load_canvas(filename)
+
+    for node_data in add_nodes or []:
+        canvas.add_node(_node_from_dict(node_data))
+
+    for patch in update_nodes or []:
+        node_id = patch.get("id")
+        existing = canvas.get_node(node_id) if node_id else None
+        if existing is None:
+            raise ValueError(f"No node with id {node_id!r} to update")
+        canvas.update_node(_node_from_dict({**existing.to_dict(), **patch}))
+
+    for edge_data in add_edges or []:
+        canvas.add_edge(Edge.from_dict(edge_data))
+
+    for patch in update_edges or []:
+        edge_id = patch.get("id")
+        existing = canvas.get_edge(edge_id) if edge_id else None
+        if existing is None:
+            raise ValueError(f"No edge with id {edge_id!r} to update")
+        canvas.update_edge(Edge.from_dict({**existing.to_dict(), **patch}))
+
+    for edge_id in remove_edge_ids or []:
+        if canvas.remove_edge(edge_id) is None:
+            raise ValueError(f"No edge with id {edge_id!r} to remove")
+
+    for node_id in remove_node_ids or []:
+        if canvas.remove_node(node_id) is None:
+            raise ValueError(f"No node with id {node_id!r} to remove")
+
+    canvas_dict = canvas.to_dict()
+    target.write_text(json.dumps(canvas_dict, indent=2))
+    print(f"Edited canvas {target}", file=sys.stderr)
+    return CreateCanvasResult(
+        path=str(target),
+        node_count=len(canvas.nodes),
+        edge_count=len(canvas.edges),
+        canvas=CanvasDocument(
+            nodes=canvas_dict.get("nodes", []),
+            edges=canvas_dict.get("edges", []),
+        ),
+    )
+
+
+@mcp.tool(
+    title="Export Canvas",
+    description=(
+        "Export a stored canvas to another format: 'markdown' (an outline that "
+        "follows the edges) or 'svg' (a standalone vector image). SVG renders each "
+        "node's title line only."
+    ),
+)
+def export_canvas(filename: str, format: Literal["markdown", "svg"]) -> ExportResult:
+    """Export a stored canvas to Markdown or SVG.
+
+    Args:
+        filename: Name of the canvas file under OUTPUT_PATH.
+        format: ``markdown`` or ``svg``.
+    """
+    _, canvas = _load_canvas(filename)
+    if format == "markdown":
+        return ExportResult(
+            format="markdown",
+            mime_type="text/markdown",
+            content=to_markdown(canvas, title=_safe_target(filename).stem),
+        )
+    return ExportResult(format="svg", mime_type="image/svg+xml", content=to_svg(canvas))
+
+
+# Fields searched per element kind (camelCase JSON keys).
+_NODE_SEARCH_FIELDS = ("text", "label", "file", "subpath", "url", "id")
+_EDGE_SEARCH_FIELDS = ("label", "id")
+_SNIPPET_MAX = 200
+
+
+def _snippet(value: str) -> str:
+    value = value.replace("\n", " ").strip()
+    return value if len(value) <= _SNIPPET_MAX else value[:_SNIPPET_MAX] + "…"
+
+
+@mcp.tool(
+    title="Search Canvases",
+    description=(
+        "Case-insensitive substring search across stored canvases. Matches node "
+        "text, labels, file paths, URLs, and IDs, plus edge labels. Searches every "
+        "canvas in OUTPUT_PATH unless a filename is given."
+    ),
+)
+def search_canvases(query: str, filename: str | None = None) -> SearchResult:
+    """Find nodes and edges whose text matches ``query``.
+
+    Args:
+        query: Case-insensitive substring to search for.
+        filename: Optional single canvas to restrict the search to (otherwise all).
+    """
+    if filename is not None:
+        targets = [_safe_target(filename)]
+    else:
+        targets = sorted(_output_dir().glob("*.canvas"))
+
+    needle = query.casefold()
+    matches: list[SearchMatch] = []
+    for target in targets:
+        if not target.is_file():
+            continue
+        try:
+            data = json.loads(target.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        for kind, fields in (
+            ("node", _NODE_SEARCH_FIELDS),
+            ("edge", _EDGE_SEARCH_FIELDS),
+        ):
+            for element in data.get(f"{kind}s", []):
+                for field in fields:
+                    value = element.get(field)
+                    if isinstance(value, str) and needle in value.casefold():
+                        matches.append(
+                            SearchMatch(
+                                filename=target.name,
+                                kind=kind,
+                                id=str(element.get("id", "")),
+                                field=field,
+                                snippet=_snippet(value),
+                            )
+                        )
+    return SearchResult(matches=matches)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -59,3 +59,41 @@ def test_empty_canvas_is_valid():
     canvas = Canvas.from_dict({})
     assert canvas.nodes == []
     assert canvas.edges == []
+
+
+def test_update_node_replaces_in_place_and_keeps_edges():
+    canvas = Canvas()
+    canvas.add_node(_node("a"))
+    canvas.add_node(_node("b"))
+    canvas.add_edge(Edge(id="e", from_node="a", to_node="b"))
+
+    old = canvas.update_node(
+        TextNode(id="a", x=5, y=5, width=20, height=20, text="new", color="4")
+    )
+    assert old.text == "a"
+    assert canvas.get_node("a").text == "new"
+    assert canvas.get_node("a").color == "4"
+    # Edge survives (unlike remove_node, which cascades).
+    assert len(canvas.edges) == 1
+
+
+def test_update_node_unknown_id_raises():
+    canvas = Canvas()
+    canvas.add_node(_node("a"))
+    with pytest.raises(ReferenceError):
+        canvas.update_node(_node("missing"))
+
+
+def test_update_edge_replaces_and_validates_references():
+    canvas = Canvas()
+    canvas.add_node(_node("a"))
+    canvas.add_node(_node("b"))
+    canvas.add_edge(Edge(id="e", from_node="a", to_node="b"))
+
+    canvas.update_edge(Edge(id="e", from_node="a", to_node="b", label="link"))
+    assert canvas.get_edge("e").label == "link"
+
+    with pytest.raises(ReferenceError):
+        canvas.update_edge(Edge(id="e", from_node="a", to_node="ghost"))
+    with pytest.raises(ReferenceError):
+        canvas.update_edge(Edge(id="missing", from_node="a", to_node="b"))

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,67 @@
+"""Tests for the canvas exporters."""
+
+from jsoncanvas import Canvas, Edge, GroupNode, LinkNode, TextNode
+from jsoncanvas.export import to_markdown, to_svg
+
+
+def _sample() -> Canvas:
+    canvas = Canvas()
+    canvas.add_node(
+        TextNode(id="root", x=0, y=0, width=200, height=100, text="# Title\n\nIntro")
+    )
+    canvas.add_node(
+        TextNode(id="child", x=0, y=200, width=200, height=100, text="## Child\n\nBody")
+    )
+    canvas.add_node(
+        GroupNode(id="grp", x=-20, y=180, width=300, height=160, label="Group A")
+    )
+    canvas.add_node(
+        LinkNode(id="lnk", x=300, y=0, width=150, height=60, url="https://example.com")
+    )
+    canvas.add_edge(Edge(id="e1", from_node="root", to_node="child", label="leads to"))
+    return canvas
+
+
+def test_to_markdown_includes_titles_body_and_connections():
+    md = to_markdown(_sample(), title="Demo")
+    assert md.startswith("# Demo")
+    assert "## Title" in md  # heading derived from first text line, '#' stripped
+    assert "Intro" in md  # body preserved
+    assert "## Connections" in md
+    assert "Title → Child — leads to" in md
+    # Root is ordered before its child (edge-ordered DFS).
+    assert md.index("## Title") < md.index("## Child")
+
+
+def test_to_markdown_handles_cycles_without_infinite_loop():
+    canvas = Canvas()
+    canvas.add_node(TextNode(id="a", x=0, y=0, width=10, height=10, text="A"))
+    canvas.add_node(TextNode(id="b", x=20, y=0, width=10, height=10, text="B"))
+    canvas.add_edge(Edge(id="e1", from_node="a", to_node="b"))
+    canvas.add_edge(Edge(id="e2", from_node="b", to_node="a"))
+    md = to_markdown(canvas)
+    assert "## A" in md and "## B" in md
+
+
+def test_to_svg_is_well_formed():
+    svg = to_svg(_sample())
+    assert svg.startswith("<svg") and svg.rstrip().endswith("</svg>")
+    assert "<rect" in svg and "<path" in svg  # nodes and an edge
+    assert "<marker" in svg  # arrowhead
+    assert "stroke-dasharray" in svg  # group node drawn dashed
+    assert "leads to" in svg  # edge label rendered
+
+
+def test_to_svg_escapes_text():
+    canvas = Canvas()
+    canvas.add_node(
+        TextNode(id="x", x=0, y=0, width=200, height=80, text="a < b & c > d")
+    )
+    svg = to_svg(canvas)
+    assert "&lt;" in svg and "&amp;" in svg and "&gt;" in svg
+    assert "a < b" not in svg  # raw angle brackets must be escaped
+
+
+def test_to_svg_empty_canvas():
+    svg = to_svg(Canvas())
+    assert svg.startswith("<svg") and "Empty canvas" in svg

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,11 +6,15 @@ from mcp.shared.memory import (
 )
 
 from jsoncanvas import server
+from jsoncanvas.errors import DuplicateIdError
 from jsoncanvas.server import (
     create_canvas,
+    edit_canvas,
+    export_canvas,
     list_canvases,
     mcp,
     read_canvas,
+    search_canvases,
     validate_canvas,
 )
 
@@ -118,6 +122,9 @@ async def test_tools_exposed_over_protocol(_output_dir):
             "validate_canvas",
             "read_canvas",
             "list_canvases",
+            "edit_canvas",
+            "export_canvas",
+            "search_canvases",
         }
 
         result = await client.call_tool(
@@ -164,3 +171,94 @@ def test_load_ui_html_returns_bundle():
     html = server._load_ui_html()
     assert "<html" in html.lower()
     assert "</html>" in html.lower()
+
+
+NODE_B = {**TEXT_NODE, "id": "b", "x": 300, "text": "world"}
+
+
+def _seed_two_node_canvas() -> str:
+    """Create a canvas with nodes a, b and edge e; return its filename."""
+    create_canvas(
+        nodes=[TEXT_NODE, NODE_B],
+        filename="edit",
+        edges=[{"id": "e", "fromNode": "a", "toNode": "b"}],
+    )
+    return list_canvases()[0]
+
+
+def test_edit_canvas_add_update_remove_round_trip(_output_dir):
+    name = _seed_two_node_canvas()
+    result = edit_canvas(
+        filename=name,
+        add_nodes=[{**TEXT_NODE, "id": "c", "x": 600, "text": "third"}],
+        update_nodes=[{"id": "a", "text": "edited", "color": "4"}],
+        add_edges=[{"id": "e2", "fromNode": "a", "toNode": "c", "label": "to c"}],
+        remove_node_ids=["b"],  # cascades edge "e"
+    )
+    node_ids = {n["id"] for n in result.canvas.nodes}
+    edge_ids = {e["id"] for e in result.canvas.edges}
+    assert node_ids == {"a", "c"}
+    assert edge_ids == {"e2"}  # original edge "e" cascaded away with node "b"
+    node_a = next(n for n in result.canvas.nodes if n["id"] == "a")
+    assert node_a["text"] == "edited" and node_a["color"] == "4"
+
+    # Persisted to disk.
+    on_disk = read_canvas(name)
+    assert {n["id"] for n in on_disk.nodes} == {"a", "c"}
+
+
+def test_edit_canvas_is_atomic_on_error(_output_dir):
+    name = _seed_two_node_canvas()
+    before = read_canvas(name).model_dump()
+    # A duplicate-id add must fail and leave the file untouched.
+    with pytest.raises(DuplicateIdError):
+        edit_canvas(filename=name, add_nodes=[TEXT_NODE])  # id "a" already exists
+    assert read_canvas(name).model_dump() == before
+
+
+def test_edit_canvas_unknown_id_raises(_output_dir):
+    name = _seed_two_node_canvas()
+    with pytest.raises(ValueError):
+        edit_canvas(filename=name, update_nodes=[{"id": "nope", "text": "x"}])
+    with pytest.raises(ValueError):
+        edit_canvas(filename=name, remove_edge_ids=["nope"])
+
+
+async def test_edit_canvas_ui_meta_and_rerender(_output_dir):
+    name = _seed_two_node_canvas()
+    async with client_session(mcp) as client:
+        by_name = {t.name: t for t in (await client.list_tools()).tools}
+        meta = by_name["edit_canvas"].meta or {}
+        assert meta.get("ui", {}).get("resourceUri") == "ui://canvas/viewer.html"
+
+        result = await client.call_tool(
+            "edit_canvas",
+            {"filename": name, "update_nodes": [{"id": "a", "text": "changed"}]},
+        )
+        assert result.isError is False
+        node_a = next(
+            n for n in result.structuredContent["canvas"]["nodes"] if n["id"] == "a"
+        )
+        assert node_a["text"] == "changed"
+
+
+def test_export_canvas_markdown_and_svg(_output_dir):
+    name = _seed_two_node_canvas()
+    md = export_canvas(filename=name, format="markdown")
+    assert md.mime_type == "text/markdown"
+    assert "## hello" in md.content and "## Connections" in md.content
+
+    svg = export_canvas(filename=name, format="svg")
+    assert svg.mime_type == "image/svg+xml"
+    assert svg.content.startswith("<svg") and "<rect" in svg.content
+
+
+def test_search_canvases_finds_and_misses(_output_dir):
+    _seed_two_node_canvas()
+    hits = search_canvases(query="world")
+    assert len(hits.matches) >= 1
+    match = hits.matches[0]
+    assert match.kind == "node" and match.id == "b" and match.field == "text"
+    assert match.filename.endswith(".canvas")
+
+    assert search_canvases(query="absolutely-not-present").matches == []


### PR DESCRIPTION
## What

Builds the canvas **editing** and **export** tools the original README promised but the pre-rewrite server never actually implemented, plus **search**. The server goes from **4 → 7 tools**.

Follow-up to the inline canvas viewer (#9): editing now closes the loop — you can mutate a stored canvas and UI-capable hosts re-render it inline.

## New tools

- **`edit_canvas`** (UI-enabled) — add/update/remove nodes and edges on a stored canvas in **one atomic write**: load → mutate in memory → validate → single write, so a failed op leaves the file untouched. Removing a node cascades its edges. Returns the updated canvas (`_meta.ui.resourceUri` set), so hosts re-render.
- **`export_canvas`** — `markdown` (edge-ordered outline) or `svg` (standalone, dependency-free vector image; node title lines only since plain SVG can't render Markdown). The SVG layout ports the viewer's anchor/bezier math to Python.
- **`search_canvases`** — case-insensitive substring search across stored canvases (node text/label/file/url/id and edge label).

## Library changes

- `Canvas.update_node` / `update_edge` — replace-by-id, no edge cascade, re-validate (raise on unknown id / dangling reference).
- Refactored `_build_canvas`'s node parsing into a reusable `_node_from_dict`.
- New `jsoncanvas/export.py` module (`to_markdown`, `to_svg`).

## Verification

- `make test` — **42 passed** (new coverage: edit round-trip, atomicity on failure, edge cascade, unknown-id errors, `edit_canvas` UI meta + re-render contract, markdown/SVG exporters incl. escaping & cycles, search hit/miss). `ruff check` + `ruff format` clean.
- **End-to-end in the ext-apps `basic-host`**: called `edit_canvas` to add a node + edge to a stored canvas and **observed the viewer re-render the mutation inline** (the new node appeared connected in the iframe), with the text fallback present in the result. SVG export was eyeballed in a browser and renders correctly (color-coded nodes, dashed group frames, arrowed bezier edges, labels).

## Notes / trade-offs

- **Tool count 4 → 7.** `edit_canvas`'s six optional array params are the main schema-complexity cost; mitigated with a detailed docstring/description.
- **SVG fidelity:** title line per node only (plain SVG can't render Markdown). Full-fidelity raster/PNG would need a headless browser — intentionally out of scope.
- `edit_canvas` writes in place (no date-prefix change), unlike `create_canvas`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)